### PR TITLE
correctly use output filename and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The code on how to freeze and save keras models in previous versions of tensorfl
 ## How to use
 The keras model can be saved using `model.save('file_name.h5')` (check keras API documentation for details).
 
-You can either use the iPython notebook (`kears_to_tensorflow.ipnyb`), or simply run the python script as below in the folder where your keras model is present:
+You can either use the iPython notebook (`keras_to_tensorflow.ipnyb`), or simply run the python script as below in the folder where your keras model is present:
 
     python3 keras_to_tensorflow.py -input_model_file model.h5
     python keras_to_tensorflow.py -input_model_file model.h5 

--- a/keras_to_tensorflow.py
+++ b/keras_to_tensorflow.py
@@ -75,7 +75,7 @@ print('input args: ', args)
 
 if args.theano_backend is True and args.quantize is True:
     raise ValueError("Quantize feature does not work with theano backend.")
-if args.input_model_file != 'model.h5':
+if args.input_model_file != 'model.h5' and args.output_model_file == 'model.pb':
     args.output_model_file = str(Path(args.input_model_file).name) + '.pb'
 
 


### PR DESCRIPTION
The keras_to_tensorflow.py script currently ignores the output model filename that you pass in. This patch fixes that.