### PR TITLE
Use compile=False when loading models

### DIFF
--- a/keras_to_tensorflow.py
+++ b/keras_to_tensorflow.py
@@ -60,7 +60,7 @@ def load_model(input_model_path, input_json_path=None, input_yaml_path=None):
         raise FileNotFoundError(
             'Model file `{}` does not exist.'.format(input_model_path))
     try:
-        model = keras.models.load_model(input_model_path)
+        model = keras.models.load_model(input_model_path, compile=False)
         return model
     except FileNotFoundError as err:
         logging.error('Input mode file (%s) does not exist.', FLAGS.input_model)


### PR DESCRIPTION
Quite often, people train models using custom losses. Then one should use compile=False when loading a keras model, as not doing so will prompt the error: 
`ValueError: Unknown loss function:some_loss_name. `

The loss is not relevant for deployment, which I'm assuming is the only application of converting the model in the first place. Thus, this should be the default. Optionally, it could have been an argument to the function, but I dont really see the point of having compile=True in the first place (for this application).

Hope you find it relevant. Your repo is the first I have found that works with multi-output networks. So thanks a ton! 🥇 